### PR TITLE
Snowflakeの公式FunctionとしてARRAY_FLATTENがリリースされたので削除。

### DIFF
--- a/snowflake_function/array_flatten.sql
+++ b/snowflake_function/array_flatten.sql
@@ -1,8 +1,0 @@
-CREATE OR REPLACE FUNCTION PROD.PUBLIC.ARRAY_FLATTEN(SRC ARRAY)
-RETURNS ARRAY
-LANGUAGE JAVASCRIPT
-AS '
-        let ret=[];
-        SRC.forEach(arr => ret = ret.concat(arr));
-        return ret;
-    ';


### PR DESCRIPTION
ARRAY_FLATTEN was released as an official Snowflake function, so it was deleted.